### PR TITLE
fix: insulin renamed to insulinSummary crashes StatsResult

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsResult.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsResult.java
@@ -179,7 +179,7 @@ public class StatsResult {
 
     public double getTotal_insulin() {
         if (total_insulin < 0) {
-            Cursor cursor = Cache.openDatabase().rawQuery("select sum(insulin) from treatments  where timestamp >= " + from + " AND timestamp <= " + to, null);
+            Cursor cursor = Cache.openDatabase().rawQuery("select sum(insulinSummary) from treatments  where timestamp >= " + from + " AND timestamp <= " + to, null);
             cursor.moveToFirst();
             total_insulin = cursor.getDouble(0);
             cursor.close();

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/stats/StatsResult.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/stats/StatsResult.java
@@ -145,7 +145,7 @@ public class StatsResult {
 
     public double getTotal_insulin() {
         if (total_insulin < 0) {
-            Cursor cursor = Cache.openDatabase().rawQuery("select sum(insulin) from treatments  where timestamp >= " + from + " AND timestamp <= " + to, null);
+            Cursor cursor = Cache.openDatabase().rawQuery("select sum(insulinSummary) from treatments  where timestamp >= " + from + " AND timestamp <= " + to, null);
             cursor.moveToFirst();
             total_insulin = cursor.getDouble(0);
             cursor.close();


### PR DESCRIPTION
the crash happens when Carb/Insulin ratio is selected in less common settings of the second status line